### PR TITLE
Fix last character showing on delete

### DIFF
--- a/assets/scripts/character/charUi.js
+++ b/assets/scripts/character/charUi.js
@@ -11,6 +11,7 @@ const onCharIndexSuccess = response => {
     const allCharsHtml = allCharsTemplate({ characters: Object.values(response) })
     $('.char-sheets', '.char-content-wrapper').html(allCharsHtml)
   } else {
+    $('.char-sheets', '.char-content-wrapper').empty()
     $('.char-message', '.char-content-wrapper').text(`You don't have any characters`)
   }
 }


### PR DESCRIPTION
When a user gets all their characters, char sheets is explicitly
emptied. This includes when they delete their last remaining character,
to avoid a nonexistent character displaying.