### PR TITLE
Improve dynamic sizing

### DIFF
--- a/assets/scripts/templates/all-chars.handlebars
+++ b/assets/scripts/templates/all-chars.handlebars
@@ -4,12 +4,12 @@
     <section class = "char-card col-md-4 border border-dark rounded bg-white" data-id="{{char.id}}">
       <h6>Name:</h6>
       <h3>
-        {{limit char.name 15}}
+        {{limit char.name 20}}
       </h3>
       <h6>High Concept:</h6>
       <p>
         {{#if char.high_concept}}
-          {{char.high_concept}}
+          {{limit char.high_concept 40}}
         {{/if}}
       </p>
       <div class="btn-container">

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -60,10 +60,13 @@ td {
 
 // .char-card {}
 
-// bootstrap breakpoint styling: sm-md
-// @media screen and (min-width: 768px) {
-// }
+// bootstrap breakpoint styling: <sm
+@media screen and (max-width: 768px) {
+  .skill-table-btn {
+    font-size: .7rem;
+  }
+}
 
-// bootstrap breakpoint styling: md-lg
+// bootstrap breakpoint styling: sm-md
 // @media screen and (min-width: 768px) and (max-width: 1000px) {
 // }


### PR DESCRIPTION
Add breakpoint css to table cells for small screens to avoid content
spilling off the screen
Limit how much of high concept displays on index